### PR TITLE
Add tests for archive / unarchive, fix unarchive bug

### DIFF
--- a/Example/Pelican.xcodeproj/xcshareddata/xcschemes/Pelican-Example.xcscheme
+++ b/Example/Pelican.xcodeproj/xcshareddata/xcschemes/Pelican-Example.xcscheme
@@ -40,7 +40,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Example/Tests/PelicanTests.swift
+++ b/Example/Tests/PelicanTests.swift
@@ -194,4 +194,16 @@ class PelicanTests: XCTestCase {
         Pelican.shared.didEnterBackground()
         XCTAssert(storage.store == nil)
     }
+
+    func testArchiveGroupsDoesNotSaveTaskGroupsToStorageWhenNoGroups() {
+        let storage = InMemoryStorage()
+        // This is done to test that we are calling deleteAll (which sets the storage to nil) properly
+        storage.store = [:]
+        let pelican = Pelican(typeToTask: [:], storage: storage)
+
+        pelican.archiveGroups()
+
+        // This should be nil, since we shouldn't call overwriteGroups
+        XCTAssertNil(storage.store)
+    }
 }

--- a/Example/Tests/PelicanTests.swift
+++ b/Example/Tests/PelicanTests.swift
@@ -244,7 +244,20 @@ class PelicanTests: XCTestCase {
         }
     }
 
-    func testUnarchiveGroupsReturnsUnarchivedTasks() {
+    func testUnarchiveGroupsLoadsNoTaskGroupsFromEmptyStorage() {
+        let storage = InMemoryStorage()
+        storage.store = [:]
+
+        let pelican = Pelican(typeToTask: [:], storage: storage)
+
+        pelican.unarchiveGroups()
+
+        XCTAssertTrue(pelican.containersByGroup.isEmpty)
+        // This should be nil, since we set storage to empty after unarchiving
+        XCTAssertNil(storage.store)
+    }
+
+    func testUnarchiveGroupsLoadsArchivedTasksFromStorage() {
         let storage = InMemoryStorage()
         let typeToTask: [String: PelicanBatchableTask.Type] = [ HouseAtreides.taskType: HouseAtreides.self ]
 

--- a/Pelican/Lib/Pelican.swift
+++ b/Pelican/Lib/Pelican.swift
@@ -194,7 +194,7 @@ public class Pelican {
     }
 }
 
-fileprivate extension Pelican {
+extension Pelican {
     // MARK: - Start or stop batch processing
 
     func start() {
@@ -248,7 +248,7 @@ fileprivate extension Pelican {
         }
     }
 
-    func toDictionary(taskGroups: Pelican.GroupedTasks) -> PelicanStorage.Serialized {
+    private func toDictionary(taskGroups: Pelican.GroupedTasks) -> PelicanStorage.Serialized {
         var dict: PelicanStorage.Serialized = [: ]
         for (group, containers) in taskGroups {
             let serialized: [[String: Any]] = containers.map { $0.containerDictionary }
@@ -257,7 +257,7 @@ fileprivate extension Pelican {
         return dict
     }
 
-    func fromDictionary(serialized: PelicanStorage.Serialized) -> Pelican.GroupedTasks {
+    private func fromDictionary(serialized: PelicanStorage.Serialized) -> Pelican.GroupedTasks {
         var taskGroups: Pelican.GroupedTasks = [: ]
         for (group, array) in serialized {
             taskGroups[group] = array.flatMap({ containerDict in

--- a/Pelican/Lib/Pelican.swift
+++ b/Pelican/Lib/Pelican.swift
@@ -269,7 +269,7 @@ extension Pelican {
             })
         }
 
-        return containersByGroup
+        return taskGroups
     }
 }
 


### PR DESCRIPTION
- Enables gathering of Code Coverage on `Pelican-Example` scheme
- Makes helper functions `internal` rather than `fileprivate` to facilitate testing of their functionality
- Adds tests for Unarchiving and Archiving task groups
- Returns populated task groups instead of empty dictionary so that persisted tasks get loaded on next launch