### PR TITLE
Configurable max chunk size

### DIFF
--- a/Pelican/Lib/Pelican.swift
+++ b/Pelican/Lib/Pelican.swift
@@ -274,8 +274,8 @@ extension Pelican {
     }
 }
 
-extension Pelican.TaskContainer: Equatable {}
-
-func == (lhs: Pelican.TaskContainer, rhs: Pelican.TaskContainer) -> Bool {
-    return lhs.identifier == rhs.identifier
+extension Pelican.TaskContainer: Equatable {
+    static func == (lhs: Pelican.TaskContainer, rhs: Pelican.TaskContainer) -> Bool {
+        return lhs.identifier == rhs.identifier
+    }
 }


### PR DESCRIPTION
Add support for a configurable max chunk size and set the default to 50 per chunk as 100 was causing a few "Payload too Large" errors with some batched requests.
A bit of cleanup around the Equatable extension was also added to put the == function inside of the extension itself.